### PR TITLE
Removed the unused using statements from the Sprite class

### DIFF
--- a/CrackerChase/Sprite.cs
+++ b/CrackerChase/Sprite.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CrackerChase
 {


### PR DESCRIPTION
There were a bunch of using statements in the Sprite class that weren't being used.